### PR TITLE
Mask authToken in console logging

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -118,7 +118,11 @@ const initConfig = () => {
     getPasskeys('/config')
         .then((configData) => {
             console.log('[Client] Get app config response');
-            console.log(configData);
+            let maskedAuthToken = configData.authToken.replace(/./g, "*");
+            let accountSid = configData.accountSid;
+            let serviceSid = configData.serviceSid;
+            const maskedConf = { accountSid, maskedAuthToken, serviceSid }
+            console.log(maskedConf);
 
             $('#account-sid').val(configData.accountSid);
             $('#auth-token').val(configData.authToken);
@@ -141,17 +145,18 @@ $(document).on('click', '#config-submit', (event) => {
 
     postPasskeys('/config', configData)
         .then(() => {
+            let maskedAuthToken = authToken.replace(/./g, "*");
+            let maskedConf = {accountSid, maskedAuthToken, serviceSid}
             showSuccess();
             console.log('[Client] Post app config response');
-            console.log(configData);
+            console.log(maskedConf);
         })
         .catch((error) => {
             console.log(error);
             showError(error);
-    }).finally(() => {
+        }).finally(() => {
         $('.loading').removeClass('loading');
     });
-
 })
 
 $(document).on('click', '#registerButton', (event) => {


### PR DESCRIPTION
Changed config logging to mask the authToken as so to avoid exposing account credentials:

<img width="515" alt="Screenshot 2024-02-12 at 11 37 06" src="https://github.com/twilio/verify-passkeys-demo-app/assets/150440099/7dc1228a-469c-4dea-beff-fbd0397e82f8">


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
